### PR TITLE
Upgrade rake to version 11.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'rake', '~> 10.0'
+gem 'rake', '~> 11.1'
 gem 'minitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ GEM
   remote: https://rubygems.org/
   specs:
     minitest (5.9.1)
-    rake (10.5.0)
+    rake (11.1.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   minitest
-  rake (~> 10.0)
+  rake (~> 11.1)
 
 BUNDLED WITH
    1.13.6


### PR DESCRIPTION
Hello,

We've upgraded a dependency and all tests pass. \o/

| gem name | version specification | old version | new version |
| --- | --- | --- | --- |
| rake | ~> 10.0 | 10.5.0 | 11.1.2 |

You should probably take a good look at this before merging this pull request, of course.









---
[Depfu](https://depfu.io) sends automated pull requests to update your Ruby dependencies.

